### PR TITLE
mjpg-streamer not working without input and output config

### DIFF
--- a/traits/special_purpose/instacam/uvc/files/etc/config/mjpg-streamer
+++ b/traits/special_purpose/instacam/uvc/files/etc/config/mjpg-streamer
@@ -1,9 +1,9 @@
 config mjpg-streamer core
         option enabled          "1"
-				option input						"uvc"
+        option input            "uvc"
         option device           "/dev/video0"
         option resolution       "1280x720"
         option fps              "15"
-				option output						"http"
+        option output           "http"
         option www              "/www/webcam"
         option port             "80"

--- a/traits/special_purpose/instacam/uvc/files/etc/config/mjpg-streamer
+++ b/traits/special_purpose/instacam/uvc/files/etc/config/mjpg-streamer
@@ -1,7 +1,9 @@
 config mjpg-streamer core
         option enabled          "1"
+				option input						"uvc"
         option device           "/dev/video0"
         option resolution       "1280x720"
         option fps              "15"
+				option output						"http"
         option www              "/www/webcam"
         option port             "80"

--- a/traits/special_purpose/instacam/zc3xx/files/etc/config/mjpg-streamer
+++ b/traits/special_purpose/instacam/zc3xx/files/etc/config/mjpg-streamer
@@ -1,9 +1,9 @@
 config mjpg-streamer core
         option enabled          "1"
-				option input						"uvc"
+	option input		"uvc"
         option device           "/dev/video0"
         option resolution       "640x480"
         option fps              "15"
-				option output						"http"
+	option output		"http"
         option www              "/www/webcam"
         option port             "80"

--- a/traits/special_purpose/instacam/zc3xx/files/etc/config/mjpg-streamer
+++ b/traits/special_purpose/instacam/zc3xx/files/etc/config/mjpg-streamer
@@ -1,7 +1,9 @@
 config mjpg-streamer core
         option enabled          "1"
+				option input						"uvc"
         option device           "/dev/video0"
         option resolution       "640x480"
         option fps              "15"
+				option output						"http"
         option www              "/www/webcam"
         option port             "80"

--- a/traits/special_purpose/instacam/zc3xx/files/etc/config/mjpg-streamer
+++ b/traits/special_purpose/instacam/zc3xx/files/etc/config/mjpg-streamer
@@ -1,9 +1,9 @@
 config mjpg-streamer core
         option enabled          "1"
-	option input		"uvc"
+        option input            "uvc"
         option device           "/dev/video0"
         option resolution       "640x480"
         option fps              "15"
-	option output		"http"
+        option output           "http"
         option www              "/www/webcam"
         option port             "80"


### PR DESCRIPTION
just installed instacam and it not worked instant..
Just add these two lines to /etc/config/mjpg-streamer and it works again
